### PR TITLE
fix(domains): Flip endpoint versus domain test -- was backwards.

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -16,7 +16,7 @@ repository:
   topics: web3, crypto, blockchain, decentralized, kubelt, dapp, federated
 
   # Either `true` to make the repository private, or `false` to make it public.
-  private: true
+  private: false
 
   # Either `true` to enable issues for this repository, `false` to disable them.
   has_issues: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Standard ignores
+.*
 !.gitignore
 !.gitattributes
 output.car

--- a/src/library.js
+++ b/src/library.js
@@ -215,7 +215,7 @@ async function start(secret, globspec, namespec, core, domain, published, skip, 
             }
 
             // If we're overriding the domain, use the override (for testing).
-            const urlbase = endpoint || domain
+            const urlbase = domain || endpoint
 
             ////////////////////////////////////////////////////////////////////
             // TODO: Needs refactor. Uses v1 endpoint for speed.

--- a/test/test.js
+++ b/test/test.js
@@ -262,7 +262,9 @@ tap.test('Test the whole deal', async t => {
     const globspec_fixture = 'test/fixtures/*.json'
     const namespec_fixture = 'path'
     const core_fixture = 'test'
-    const domain_fixture = 'https://api.pndo.xyz'
+    const domain_fixture = 'https://staging.pndo.xyz'
+    //const domain_fixture = 'https://api.pndo.xyz'
+    //const domain_fixture = 'https://pndo-worker-staging.admin1337.workers.dev'
     const published_fixture = true
     const skip_fixture = false
     const as_fixture = 'dag'
@@ -270,6 +272,8 @@ tap.test('Test the whole deal', async t => {
 
     // Assumes `wrangler dev` is serving the pando worker locally.
     const test_endpoint = 'http://127.0.0.1:8787'
+    //const test_endpoint = 'http://127.0.0.1:8787'
+    //const test_endpoint = 'http://127.0.0.1:8787'
 
     // TODO: This should take a mock because it fires requests.
     const results = await lib.start(secret_fixture,
@@ -283,7 +287,7 @@ tap.test('Test the whole deal', async t => {
         limit,
         test_endpoint)
 
-    const result_fixture = [{"expirationTtl":86400,"metadata":{"published":true,"human":"revealed.json","path":"test/fixtures/revealed.json","as":"dag","box":{"cid":"bafyreicdv7bpbli5xqkm453qljawxrl4caikjojzhlcp4c5crthvwbvgbu","name":"/test/revealed.json","key":"CAESQKLPatJ7QPYjygqYv2YRUPoRKw+fRaINKXcmp8xPVb8de6u6be4mcs6OC5emBCaRRe960HXauD89OAOpsnXV4u8="}}},{"expirationTtl":86400,"metadata":{"published":true,"human":"unrevealed.json","path":"test/fixtures/unrevealed.json","as":"dag","box":{"cid":"bafyreiakhygqrybainjazlvdntdso3jusx5zx3hhuqkdddmymbffj7f7te","name":"/test/unrevealed.json","key":"CAESQOB66d7n8WB3KjjfmYrN6Da6sAieEZ3DnORhLjkgk/h8I1r7XMIobF0nekvF1G7ONspbQAFrPP9szUszGvx2kV8="}}}]
+    const result_fixture = [{"metadata":{"published":true,"human":"revealed.json","path":"test/fixtures/revealed.json","as":"dag","box":{"cid":"bafyreicdv7bpbli5xqkm453qljawxrl4caikjojzhlcp4c5crthvwbvgbu","name":"/test/revealed.json","key":"CAESQKLPatJ7QPYjygqYv2YRUPoRKw+fRaINKXcmp8xPVb8de6u6be4mcs6OC5emBCaRRe960HXauD89OAOpsnXV4u8="}}},{"metadata":{"published":true,"human":"unrevealed.json","path":"test/fixtures/unrevealed.json","as":"dag","box":{"cid":"bafyreiakhygqrybainjazlvdntdso3jusx5zx3hhuqkdddmymbffj7f7te","name":"/test/unrevealed.json","key":"CAESQOB66d7n8WB3KjjfmYrN6Da6sAieEZ3DnORhLjkgk/h8I1r7XMIobF0nekvF1G7ONspbQAFrPP9szUszGvx2kV8="}}}]
     t.match(results, result_fixture)
 
     const skipKeyResults = await lib.start(secret_fixture,


### PR DESCRIPTION
# Why

We want to be able to test domains independently of the worker we test against, so the domain and the endpoint are separate concepts. This fixes their order of evaluations -- we want to run against the domain specified.

# What

Flip the condition.

# Notes

- Requires additional hookup for specifying headers correctly, and in Pando.